### PR TITLE
fix: change label of infection to Post-operative complications

### DIFF
--- a/src/pages/EpisodeDetails/components/ExpandableContainer/components/Discharge.tsx
+++ b/src/pages/EpisodeDetails/components/ExpandableContainer/components/Discharge.tsx
@@ -176,7 +176,7 @@ const Discharge: FC<{
                 )}
 
                 <FieldWrapper>
-                  <label>Infection</label>
+                  <label>Post-operative complications</label>
                   <CheckBoxWrapper>
                     {POST_OPERATIVE_COMPLICATIONS.map((option) => (
                       <div key={option.label}>


### PR DESCRIPTION
## Description

<!-- Write and explain of the changes introduced by this PR for the reviewers to fully understand -->

Changing the `infection` wording in Discharge page to `Post-operative complications` 
