### PR TITLE
Improved Surgeon search and small label fix

### DIFF
--- a/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
+++ b/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
@@ -17,7 +17,7 @@ import {
   SelectWrapper,
 } from '../../../../RegisterEpisode/components/RegisterEpisodeForm/RegisterEpisodeForm.style';
 import { BOOLEAN_OPTIONS, FOLLOW_UP_PAIN_OPTIONS } from '../../../../RegisterEpisode/constants';
-import { getSurgeonOptions } from '../../../../RegisterEpisode/utils';
+import { getSurgeonOptionsSorted } from '../../../../RegisterEpisode/utils';
 import { InternalContainer } from '../style';
 import { FieldWrapper } from './style';
 
@@ -34,7 +34,7 @@ const FollowUps: FC<{
     limit: 100,
   });
 
-  const surgeonOptions = useMemo(() => getSurgeonOptions(surgeons?.results ?? []), [surgeons]);
+  const surgeonOptions = useMemo(() => getSurgeonOptionsSorted(surgeons?.results ?? []), [surgeons]);
 
   const handleSubmit = (form: FollowUpForm) => {
     mutate(form);
@@ -103,7 +103,7 @@ const FollowUps: FC<{
                                     <Select
                                       id="id"
                                       label="Surgeon"
-                                      isSearchable={false}
+                                      isSearchable={true}
                                       styleType="outlined"
                                       size="md"
                                       locked={!canSubmit}

--- a/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
+++ b/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
@@ -355,7 +355,7 @@ const FollowUps: FC<{
                           <Select
                             locked={!canSubmit}
                             id="further_surgery_need"
-                            label="Need further surgery?"
+                            label="Need for further surgery?"
                             styleType="outlined"
                             size="md"
                             required={canSubmit}

--- a/src/pages/RegisterEpisode/components/RegisterEpisodeForm/RegisterEpisodeForm.tsx
+++ b/src/pages/RegisterEpisode/components/RegisterEpisodeForm/RegisterEpisodeForm.tsx
@@ -24,7 +24,7 @@ import {
   EPISODE_TYPE_OPTIONS,
 } from '../../constants';
 import { RegisterEpisodeFormType } from '../../types';
-import { getHospitalOptions, getSurgeonOptions } from '../../utils';
+import {getHospitalOptions, getSurgeonOptionsSorted} from '../../utils';
 import {
   ArrayContainer,
   FormContainer,
@@ -65,7 +65,7 @@ const RegisterEpisodeForm: React.FC<Props> = ({
 }) => {
   const { isDesktop } = useResponsiveLayout();
   const hospitalOptions = useMemo(() => getHospitalOptions(hospitals), [hospitals]);
-  const surgeonOptions = useMemo(() => getSurgeonOptions(surgeons), [surgeons]);
+  const surgeonOptions = useMemo(() => getSurgeonOptionsSorted(surgeons), [surgeons]);
 
   const defaultHospital = useMemo(
     () => ({ value: selectedHospital?.id, label: selectedHospital?.name }),
@@ -489,7 +489,7 @@ const RegisterEpisodeForm: React.FC<Props> = ({
                         <Select
                           id="id"
                           label="Surgeon"
-                          isSearchable={false}
+                          isSearchable={true}
                           styleType="outlined"
                           size="md"
                           required

--- a/src/pages/RegisterEpisode/utils.ts
+++ b/src/pages/RegisterEpisode/utils.ts
@@ -19,6 +19,16 @@ export const getSurgeonOptions = (surgeons: SurgeonsAPI[]): SelectOption[] => {
   }));
 };
 
+export const getSurgeonOptionsSorted = (surgeons: SurgeonsAPI[]): SelectOption[] => {
+  const options: SelectOption[] = surgeons.map((surgeon) => ({
+    label: `${surgeon?.user.first_name} ${surgeon?.user.last_name}` ?? '',
+    value: surgeon?.id,
+  }));
+  // Sort the options by label
+  options.sort((a, b) => a.label.localeCompare(b.label));
+  return options;
+};
+
 export const formValidation = (values: RegisterEpisodeFormType, isNewHospital: boolean) => {
   const errors = {} || {
     hospital: '',


### PR DESCRIPTION
## Description

1. Changed label 'Need further surgery?' to 'Need for further surgery?' in the Follow Ups form
2. Added the ability to search for surgeons by typing the name when clicking the surgeon dropdown menus in the register episode and follow up pages. The surgeons now appear in alphabetical order.

## Screenshot

![image](https://github.com/swiftss-org/registry-client/assets/4975522/9e433d3e-244f-4ff2-a2ee-2c44f4043d55)

![image](https://github.com/swiftss-org/registry-client/assets/4975522/be4a350a-2711-4aa3-899f-9e5eb28f909b)

## Test Plan

Search function tested with multiple users present and it behaves as expected.
