### PR TITLE
Added Recurrence option to Followups

### DIFF
--- a/src/hooks/api/patientHooks.ts
+++ b/src/hooks/api/patientHooks.ts
@@ -297,6 +297,7 @@ export const useFollowUp = (episodeID: string) => {
         seroma: params?.seroma.label === 'Yes',
         infection: params?.infection.label === 'Yes',
         numbness: params?.numbness.label === 'Yes',
+        recurrence: params?.recurrence.label === 'Yes',
         pain_severity: params?.pain_severity.label,
         further_surgery_need: params?.further_surgery_need.label === 'Yes',
         surgery_comments_box: params?.surgery_comments_box,

--- a/src/models/apiTypes.tsx
+++ b/src/models/apiTypes.tsx
@@ -75,6 +75,7 @@ export type FollowUpAPI = {
   seroma: boolean;
   infection: boolean;
   numbness: boolean;
+  recurrence: boolean;
   further_surgery_need: boolean;
   surgery_comments_box?: string;
 };
@@ -87,6 +88,7 @@ export type FollowUpPayload = {
   seroma: boolean;
   infection: boolean;
   numbness: boolean;
+  recurrence: boolean;
 };
 
 export type FollowUpForm = {
@@ -100,6 +102,7 @@ export type FollowUpForm = {
   seroma: SelectOption;
   infection: SelectOption;
   numbness: SelectOption;
+  recurrence: SelectOption;
   further_surgery_need: SelectOption;
   surgery_comments_box?: string;
 };

--- a/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
+++ b/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
@@ -335,6 +335,44 @@ const FollowUps: FC<{
                 </FieldWrapper>
                 <FieldWrapper>
                   <Field
+                    name="recurrence"
+                    initialValue={
+                      followUp?.recurrence !== undefined
+                        ? BOOLEAN_OPTIONS.find((option) =>
+                            followUp?.recurrence ? option.label === 'Yes' : option.label === 'No'
+                          )
+                        : undefined
+                    }
+                  >
+                    {(props) => {
+                      const hasError =
+                        props.meta.touched && props.meta.invalid && !props.meta.active;
+
+                      return (
+                        <SelectWrapper>
+                          <Select
+                            locked={!canSubmit}
+                            id="recurrence"
+                            label="Recurrence"
+                            styleType="outlined"
+                            size="md"
+                            required={canSubmit}
+                            status={hasError ? 'error' : 'hint'}
+                            hintMsg={hasError ? props.meta.error : undefined}
+                            options={BOOLEAN_OPTIONS}
+                            {...omit(props.input, ['onFocus'])}
+                            selectedOption={BOOLEAN_OPTIONS.find(
+                              (option) => option.value === props.input.value.value
+                            )}
+                            handleSelectedOption={props.input.onChange}
+                          />
+                        </SelectWrapper>
+                      );
+                    }}
+                  </Field>
+                </FieldWrapper>
+                <FieldWrapper>
+                  <Field
                     name="further_surgery_need"
                     initialValue={
                       followUp?.further_surgery_need !== undefined


### PR DESCRIPTION
## Description

Added a compulsory Yes/No field called Recurrence between “Numbness” and “Need further surgery”. This requires the new field in the database introduced in this [commit](https://github.com/swiftss-org/registry-api/commit/f0c3734e01f935d3c6febfaa7561c7b0c68a8e58)

## Screenshot

![image](https://github.com/user-attachments/assets/3a733438-21a7-4253-b8cd-aa9033dfb073)

## Test Plan

Tested with new follow ups, both using the Yes and No options. Tested on older follow ups, where this shows as a "No" on the client side, and as an "Unknown" on the admin site.
