### PR TITLE
Implemented a first version of a surgeon dashboard landing page

### DIFF
--- a/src/api/patientsAPI/patientsAPI.tsx
+++ b/src/api/patientsAPI/patientsAPI.tsx
@@ -29,4 +29,6 @@ export default {
   dischargePatient: (params: DischargePayload) => request(METHODS.POST, `/discharges/`, { params }),
   followUpPatient: (params: FollowUpPayload) => request(METHODS.POST, `/follow-ups/`, { params }),
   getPreferredHospital: () => request(METHODS.GET, '/preferred-hospital/retrieve_for_current_user/', {}),
+  getSurgeonEpisodeSummary: () => request(METHODS.GET, '/surgeon-episode-summary/', {}),
+  getOwnedEpisodes: () => request(METHODS.GET, '/owned-episodes/', {}),
 };

--- a/src/hooks/api/patientHooks.ts
+++ b/src/hooks/api/patientHooks.ts
@@ -14,12 +14,15 @@ import {
   HospitalMappingPayload,
   HospitalsAPI,
   HospitalsResponse,
+  OwnedEpisodeAPI,
   PaginationParams,
   PatientAPI,
   PatientsPayload,
-  PatientsResponse, PreferredHospital,
+  PatientsResponse,
+  PreferredHospital,
   RegisterEpisodePayload,
   RegisterPatientPayload,
+  SurgeonEpisodeSummaryAPI,
   SurgeonsResponse,
 } from '../../models/apiTypes';
 import { RegisterEpisodeFormType } from '../../pages/RegisterEpisode/types';
@@ -53,6 +56,38 @@ export const useGetPreferredHospital = () => {
     {
       onError: (error) => {
         console.error("Error fetching preferred hospital:", error);
+      },
+      retry: false,
+    }
+  );
+};
+
+export const useGetSurgeonEpisodeSummary = () => {
+  return useQuery<SurgeonEpisodeSummaryAPI, AxiosError, SurgeonEpisodeSummaryAPI>(
+    ReactQueryKeys.SurgeonEpisodeSummaryQuery,
+    async () => {
+      const { request } = patientsAPI.single.getSurgeonEpisodeSummary();
+      return await request();
+    },
+    {
+      onError: (error) => {
+        console.error("Error fetching surgeon episode stats:", error);
+      },
+      retry: false,
+    }
+  );
+};
+
+export const useGetOwnedEpisodes = () => {
+  return useQuery<OwnedEpisodeAPI[], AxiosError>(
+    ReactQueryKeys.OwnedEpisodesQuery,
+    async () => {
+      const { request } = patientsAPI.single.getOwnedEpisodes();
+      return await request();
+    },
+    {
+      onError: (error: AxiosError) => {
+        console.error("Error fetching owned episodes:", error);
       },
       retry: false,
     }
@@ -333,3 +368,4 @@ export const useFollowUp = (episodeID: string) => {
     }
   );
 };
+

--- a/src/hooks/api/userHooks.ts
+++ b/src/hooks/api/userHooks.ts
@@ -33,7 +33,7 @@ export const useSignIn = () => {
         setUserStorageItem(__EMAIL__, data?.user.email ?? '');
         setAxiosToken(data?.token ?? '');
 
-        history.replace(urls.patients());
+        history.replace(urls.landingPage());
       },
       onError: (errors) => {
         setNotification('Invalid credential combination.', 'error');

--- a/src/hooks/constants.ts
+++ b/src/hooks/constants.ts
@@ -4,4 +4,6 @@ export const ReactQueryKeys = {
   SurgeonsQuery: 'surgeonsQuery',
   EpisodesQuery: 'episodesQuery',
   PreferredHospitalQuery: 'preferredHospital',
+  SurgeonEpisodeSummaryQuery: 'surgeonEpisodeSummary',
+  OwnedEpisodesQuery: 'ownedEpisodes',
 };

--- a/src/models/apiTypes.tsx
+++ b/src/models/apiTypes.tsx
@@ -221,3 +221,18 @@ export interface PreferredHospital {
     id: number;
   };
 }
+
+export type SurgeonEpisodeSummaryAPI = {
+  episode_count: number;
+  last_episode_date: string;
+};
+
+export type OwnedEpisodeAPI = {
+  id: number;
+  surgery_date: string;
+  patient_name: string;
+  discharge: DischargeAPI | null;
+  follow_up_dates: FollowUpAPI[];
+  patient_id: number;
+  hospital_id: number;
+};

--- a/src/pages/LandingPage/LandingPage.style.tsx
+++ b/src/pages/LandingPage/LandingPage.style.tsx
@@ -1,0 +1,24 @@
+import styled from '@emotion/styled';
+
+import { scrollBar } from '../../common.style';
+
+export const DashboardWrapper = styled.div`
+  ${scrollBar};
+  margin-bottom: 16px;
+  overflow-y: auto;
+  padding: 0px 16px 18px 16px;
+  @media (max-width: 1200px) {
+    height: calc(100vh - 280px);
+  }
+}
+`;
+
+export const DashboardText = styled.div`
+  color: ${(props) => props.theme.utils.getColor('darkGray', 400)};
+`;
+
+export const DashboardTextHeader = styled.div`
+  color: ${(props) => props.theme.utils.getColor('darkGray', 400)};
+  font-size: 14px;
+  font-weight: 400;
+`;

--- a/src/pages/LandingPage/LandingPage.tsx
+++ b/src/pages/LandingPage/LandingPage.tsx
@@ -1,0 +1,223 @@
+import React, { useState } from 'react';
+
+import { Button } from '@orfium/ictinus';
+import { useGetSurgeonEpisodeSummary, useGetOwnedEpisodes } from 'hooks/api/patientHooks';
+import { useHistory } from 'react-router-dom';
+import urls from 'routing/urls';
+
+import {
+  ButtonContainer, PageTitle,
+  PageWrapper,
+} from '../../common.style';
+import { useResponsiveLayout } from '../../hooks/useResponsiveSidebar';
+import { OwnedEpisodeAPI } from '../../models/apiTypes';
+import { DashboardText, DashboardTextHeader, DashboardWrapper } from './LandingPage.style';
+
+const LandingPage: React.FC = () => {
+  const { data: surgeonEpisodeSummary, error: surgeonError } = useGetSurgeonEpisodeSummary();
+  const { data: ownedEpisodes = [], error: episodesError } = useGetOwnedEpisodes();
+  const history = useHistory();
+  const { isDesktop } = useResponsiveLayout();
+
+  // State to handle sorting
+  const [sortConfig, setSortConfig] = useState<{
+    key: keyof OwnedEpisodeAPI | 'discharged';
+    direction: 'ascending' | 'descending';
+  }>({
+    key: 'surgery_date', // Default sort by surgery date
+    direction: 'descending',
+  });
+
+  // Function to handle sorting when a column header is clicked
+  const handleSort = (key: keyof OwnedEpisodeAPI | 'discharged') => {
+    let direction: 'ascending' | 'descending' = 'ascending';
+    if (sortConfig.key === key && sortConfig.direction === 'ascending') {
+      direction = 'descending';
+    }
+    setSortConfig({ key, direction });
+  };
+
+  // Sort ownedEpisodes based on sortConfig
+  const sortedEpisodes = ownedEpisodes
+    ? [...ownedEpisodes].sort((a: OwnedEpisodeAPI, b: OwnedEpisodeAPI) => {
+
+        // Custom sorting for follow_up_dates
+        if (sortConfig.key === 'follow_up_dates') {
+          const aFollowUps = a.follow_up_dates.length;
+          const bFollowUps = b.follow_up_dates.length;
+          return sortConfig.direction === 'ascending'
+            ? aFollowUps - bFollowUps
+            : bFollowUps - aFollowUps;
+        }
+
+        // Custom sorting for discharge status
+        if (sortConfig.key === 'discharged') {
+          const aHasDischarge = a.discharge !== null ? 1 : 0; // 1 if has discharge, 0 if not
+          const bHasDischarge = b.discharge !== null ? 1 : 0; // 1 if has discharge, 0 if not
+          return sortConfig.direction === 'ascending' ? aHasDischarge - bHasDischarge : bHasDischarge - aHasDischarge;
+        }
+
+        // Fallback to other sorting keys
+        const aValue = a[sortConfig.key] ?? '';
+        const bValue = b[sortConfig.key] ?? '';
+
+        if (aValue < bValue) {
+          return sortConfig.direction === 'ascending' ? -1 : 1;
+        }
+        if (aValue > bValue) {
+          return sortConfig.direction === 'ascending' ? 1 : -1;
+        }
+        return 0;
+      })
+    : [];
+
+  const handleRowClick = (episode: OwnedEpisodeAPI) => {
+    const { hospital_id, patient_id, id } = episode;
+    history.push(`${urls.patients()}/${hospital_id}/${patient_id}${urls.episodes()}/${id}`);
+  };
+
+  return (
+    <PageWrapper isDesktop={isDesktop}>
+      <PageTitle>
+        Surgeon Dashboard
+      </PageTitle>
+      <DashboardWrapper>
+        <DashboardText>
+          This is your personalized landing page with key insights on the episodes you have performed.
+        </DashboardText>
+        {/* Handle error state */}
+        {surgeonError && <div style={{ color: 'red' }}>Failed to load surgeon stats: {surgeonError.message}</div>}
+        {episodesError && <div style={{ color: 'red' }}>Failed to load episodes: {episodesError.message}</div>}
+
+        {/* Render surgeon summary data */}
+        {surgeonEpisodeSummary ? (
+          <DashboardText>
+            <p>Number of episodes: {surgeonEpisodeSummary.episode_count}</p>
+            <p>
+              Last episode:{' '}
+              {surgeonEpisodeSummary.last_episode_date
+                ? new Date(surgeonEpisodeSummary.last_episode_date).toLocaleDateString()
+                : 'N/A'}
+            </p>
+          </DashboardText>
+        ) : (
+
+          <DashboardText>Loading surgeon summary...</DashboardText>
+        )}
+
+        {/* Render owned episodes table */}
+        {ownedEpisodes ? (
+          ownedEpisodes.length > 0 ? (
+            <div>
+              <DashboardTextHeader>
+                <h2>Your Episodes</h2>
+              </DashboardTextHeader>
+              <DashboardText>
+                <p>
+                  Click on a column header to order results by that column, or click on a row to see the details of that
+                  episode.
+                </p>
+              </DashboardText>
+              <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+                <thead>
+                  <tr>
+                    <th
+                      onClick={() => handleSort('surgery_date')}
+                      style={{ border: '1px solid lightgrey', padding: '8px', cursor: 'pointer' }}
+                    >
+                      Surgery Date{' '}
+                      {sortConfig.key === 'surgery_date'
+                        ? sortConfig.direction === 'ascending'
+                          ? '↑'
+                          : '↓'
+                        : ''}
+                    </th>
+                    <th
+                      onClick={() => handleSort('patient_name')}
+                      style={{ border: '1px solid lightgrey', padding: '8px', cursor: 'pointer' }}
+                    >
+                      Patient Name{' '}
+                      {sortConfig.key === 'patient_name'
+                        ? sortConfig.direction === 'ascending'
+                          ? '↑'
+                          : '↓'
+                        : ''}
+                    </th>
+                    <th
+                      onClick={() => handleSort('follow_up_dates')}
+                      style={{ border: '1px solid lightgrey', padding: '8px', cursor: 'pointer' }}
+                    >
+                      Follow-ups{' '}
+                      {sortConfig.key === 'follow_up_dates'
+                        ? sortConfig.direction === 'ascending'
+                          ? '↑'
+                          : '↓'
+                        : ''}
+                    </th>
+                    <th
+                      onClick={() => handleSort('discharged')}
+                      style={{ border: '1px solid lightgrey', padding: '8px', cursor: 'pointer' }}
+                    >
+                      Discharged{' '}
+                      {sortConfig.key === 'discharged'
+                        ? sortConfig.direction === 'ascending'
+                          ? '↑'
+                          : '↓'
+                        : ''}
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedEpisodes.map((episode) => (
+                    <tr
+                      key={episode.id}
+                      onClick={() => handleRowClick(episode)}
+                      style={{
+                        cursor: 'pointer',
+                        borderBottom: '1px solid lightgrey',
+                        backgroundColor: episode.discharge ? 'inherit' : '#fc7c7c',
+                      }}
+                    >
+                      <td style={{ border: '1px solid lightgrey', padding: '8px' }}>
+                        {new Date(episode.surgery_date).toLocaleDateString()}
+                      </td>
+                      <td style={{ border: '1px solid lightgrey', padding: '8px' }}>{episode.patient_name}</td>
+                      <td style={{ border: '1px solid lightgrey', padding: '8px' }}>{episode.follow_up_dates.length}</td>
+                      <td style={{ border: '1px solid lightgrey', padding: '8px' }}>
+                        {episode.discharge ? 'Yes' : 'No'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div>
+              <DashboardTextHeader>
+                <h2>Your Episodes</h2>
+              </DashboardTextHeader>
+              <DashboardText>
+                <p>You have not recorded any episodes yet.</p>
+              </DashboardText>
+            </div>
+          )
+        ) : (
+          <DashboardText>Loading episodes...</DashboardText>
+        )}
+      </DashboardWrapper>
+      <ButtonContainer isDesktop={isDesktop}>
+        <Button
+          buttonType="button"
+          block
+          filled
+          size="md"
+          onClick={() => history.push(urls.patients())}
+        >
+          Go to Patient Directory
+        </Button>
+      </ButtonContainer>
+    </PageWrapper>
+  );
+};
+
+export default LandingPage;

--- a/src/pages/LandingPage/index.ts
+++ b/src/pages/LandingPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LandingPage';

--- a/src/pages/Layout/Layout.tsx
+++ b/src/pages/Layout/Layout.tsx
@@ -63,6 +63,12 @@ const Layout: React.FC<Props> = ({ component: Component }) => {
               url: '/patients/register',
               options: [],
             },
+            {
+              name: 'Dashboard',
+              visible: true,
+              url: '/patients/landing',
+              options: [],
+            },
             // {
             //   name: 'My Account',
             //   visible: true,

--- a/src/routing/PrivateRoute.tsx
+++ b/src/routing/PrivateRoute.tsx
@@ -12,7 +12,7 @@ const PrivateRoute: React.FC<CustomRouteProps> = ({ component: Component, ...res
   const token = getUserStorageItem(__TOKEN__);
 
   if (!token) {
-    return <Route {...rest} render={() => <Redirect to={urls.login()} />} />;
+    return <Route {...rest} render={() => <Redirect to={urls.landingPage()} />} />;
   }
   if (rest.path === '/' || !Component) {
     return <Redirect to={urls.patients()} />;

--- a/src/routing/PublicRoute.tsx
+++ b/src/routing/PublicRoute.tsx
@@ -12,7 +12,7 @@ const PublicRoute: React.FC<CustomRouteProps> = ({ component: Component, ...rest
   const token = getUserStorageItem(__TOKEN__);
 
   if (token && rest.path === urls.login()) {
-    return <Route {...rest} render={() => <Redirect to={urls.patients()} />} />;
+    return <Route {...rest} render={() => <Redirect to={urls.landingPage()} />} />;
   }
 
   return (

--- a/src/routing/Routes.tsx
+++ b/src/routing/Routes.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import LandingPage from 'pages/LandingPage';
 import Login from 'pages/Login';
 import PatientDirectory from 'pages/PatientDirectory';
 import RegisterPatient from 'pages/RegisterPatient';
@@ -33,9 +34,9 @@ const Routes: React.FC = () => (
       path={`${urls.patients()}/:hospitalID/:patientID`}
       component={PatientDetails}
     />
-
     <PrivateRoute exact path={[urls.patients()]} component={PatientDirectory} />
-    <Redirect to={urls.patients()} />
+    <PrivateRoute exact path={urls.landingPage()} component={LandingPage} />
+    <Redirect to={urls.login()} />
   </Switch>
 );
 

--- a/src/routing/urls.ts
+++ b/src/routing/urls.ts
@@ -5,6 +5,7 @@ const urls = {
   patients: () => '/patients',
   registerPatient: () => '/patients/register',
   episodes: () => '/episodes',
+  landingPage: () => '/landing',
 };
 
 export default urls;


### PR DESCRIPTION

First implementation of a landing page. The current functionality is as follows:

* When the user logs in the “Dashboard” page is opened (see screenshot below)
* The user can click on the “Go to Patient Directory” button at the top, or click on the “Patient Directory” menu item on the left to reach the patient directory and continue using the site as usual.
* If the user wants to see the dashboard again, they need to click on the Dashboard button of the menu on the left.
* The dashboard currently shows the total number of episodes the surgeon was involved in, along with the date of the last such episode.
* Below this information, there is a table that summarises the episodes that the logged in user is recorded as having participated in.
* The table lists the date of the surgery, the name of the patient, the number of follow ups, and whether a discharge has happened or not.
* Clicking on the table headers cause the table to be sorted by the values on that column in ascending or descending values.
* Clicking on any row on this table will open the details of that particular episode that is represented in that row.
* The table has a max height, so if too many rows are present, it will show a side scrolling bar. However the results are not paginated yet, so there might be issues if a surgeon is associated with several hundreds of episodes.
* The table only shows information about episodes that list the registered user as one of the surgeons. It does not currently show information about episodes where the surgeon is only listed in the discharge or follow-up information.
* This page currently has a soft limit of a few hundred episodes per surgeon, beyond which a different visualisation should be implemented.
* Episodes without discharge are highlighted in red
* The tables do not show if no rows are pulled from the database