### PR TITLE
activate input form validation

### DIFF
--- a/src/pages/EpisodeDetails/components/ExpandableContainer/components/Discharge.tsx
+++ b/src/pages/EpisodeDetails/components/ExpandableContainer/components/Discharge.tsx
@@ -15,16 +15,17 @@ import {
   SelectWrapper,
 } from '../../../../RegisterEpisode/components/RegisterEpisodeForm/RegisterEpisodeForm.style';
 import { BOOLEAN_OPTIONS } from '../../../../RegisterEpisode/constants';
+import { dischargeFormValidation } from '../../../utils';
 import { InternalContainer } from '../style';
 import { FieldWrapper } from './style';
 
 const POST_OPERATIVE_COMPLICATIONS = [
+  { label: 'None' },
   { label: 'Bleeding' },
   { label: 'Haematoma' },
   { label: 'Urinary Retention' },
   { label: 'Return to theatre' },
-  { label: 'Death' },
-  { label: 'None' },
+  { label: 'Death' }
 ];
 
 const Discharge: FC<{
@@ -60,6 +61,7 @@ const Discharge: FC<{
           // @ts-ignore
           handleSubmit(newValues);
         }}
+        validate={(values) => dischargeFormValidation(values)}
         initialValues={{
           ...discharge,
           infection: discharge && discharge.infection ? discharge.infection?.split(',') : undefined,
@@ -193,6 +195,29 @@ const Discharge: FC<{
                       </div>
                     ))}
                   </CheckBoxWrapper>
+                  <Field
+                    name="infection"
+                    initialValue={discharge?.discharge_duration}
+                    parse={(value) => value}
+                  >
+                    {(props) => {
+                      const hasError =
+                        props.meta.touched && props.meta.invalid && !props.meta.active;
+                      return (
+                        <TextField
+                          id="infection"
+                          disabled
+                          label={'Infection'}
+                          required={canSubmit}
+                          styleType="outlined"
+                          size="md"
+                          status={hasError ? 'error' : 'hint'}
+                          hintMsg={hasError ? props.meta.error : undefined}
+                          {...props.input}
+                        />
+                      );
+                    }}
+                  </Field>
                 </FieldWrapper>
 
                 <FieldWrapper>
@@ -220,7 +245,7 @@ const Discharge: FC<{
                   color={'blue-200'}
                   buttonType="button"
                   onClick={handleSubmit}
-                  disabled={isLoading || !canSubmit || !values.infection}
+                  disabled={isLoading}
                   block
                   size="md"
                 >

--- a/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
+++ b/src/pages/EpisodeDetails/components/ExpandableContainer/components/FollowUps.tsx
@@ -18,12 +18,14 @@ import {
 } from '../../../../RegisterEpisode/components/RegisterEpisodeForm/RegisterEpisodeForm.style';
 import { BOOLEAN_OPTIONS, FOLLOW_UP_PAIN_OPTIONS } from '../../../../RegisterEpisode/constants';
 import { getSurgeonOptionsSorted } from '../../../../RegisterEpisode/utils';
+import { followUpFormValidation } from '../../../utils';
 import { InternalContainer } from '../style';
 import { FieldWrapper } from './style';
 
 const FollowUps: FC<{
   isOpen: boolean;
   followUp: FollowUpAPI;
+  values: FollowUpForm;
 }> = ({ isOpen, followUp }) => {
   const match = useRouteMatch<{ episodeID: string }>();
   const { episodeID } = match.params;
@@ -47,6 +49,7 @@ const FollowUps: FC<{
         mutators={{
           ...arrayMutators,
         }}
+        validate={(values) => followUpFormValidation(values)}
         onSubmit={handleSubmit}
       >
         {({
@@ -443,7 +446,7 @@ const FollowUps: FC<{
                   color={'blue-200'}
                   buttonType="button"
                   onClick={handleSubmit}
-                  disabled={isLoading || !canSubmit || isSurgeonsLoading}
+                  disabled={isLoading || isSurgeonsLoading}
                   block
                   size="md"
                 >

--- a/src/pages/EpisodeDetails/utils.ts
+++ b/src/pages/EpisodeDetails/utils.ts
@@ -1,0 +1,101 @@
+import { FollowUpForm, SelectOption } from '../../models/apiTypes';
+
+const REQUIRED_FIELD_MSG = 'This field is required';
+
+export const dischargeFormValidation = (values: {
+                                                    date?: string;
+                                                    aware_of_mesh?: SelectOption;
+                                                    infection?: string;
+                                                    comments?: string;
+                                                    discharge_duration?: string;
+                                                  }) => {
+    const errors = {} || {
+        date: '',
+        discharge_duration: '',
+        aware_of_mesh: '',
+        infection: ''
+    };
+
+    if (!values.date?.trim()) {
+        errors.date = REQUIRED_FIELD_MSG + '. Please select a date.';
+    }
+
+    if (values.date && new Date(values.date?.trim()) > new Date()) {
+        errors.date = 'Discharge date cannot be set in the future.';
+    }
+
+    if (!values.aware_of_mesh && typeof values.aware_of_mesh !== 'object') {
+        errors.aware_of_mesh = REQUIRED_FIELD_MSG;
+    } else {
+        console.log(values)
+
+        if (!values.discharge_duration && typeof values.discharge_duration !== 'object') {
+            errors.discharge_duration = REQUIRED_FIELD_MSG;
+        }
+    }
+
+    if (values.infection === undefined || values.infection?.length == 0) {
+        const errorMessage = "Please record the post-operative complication above. if there wasn't any then select the option 'None'";
+        errors.infection = errorMessage;
+    }
+    return errors;
+};
+
+export const followUpFormValidation = (values: FollowUpForm) => {
+  const errors = {} || {
+    pain_severity: '',
+    date: '',
+    attendees: '',
+    mesh_awareness: '',
+    seroma: '',
+    infection: '',
+    numbness: '',
+    recurrence: '',
+    further_surgery_need: ''
+  };
+
+  if (!values.date?.trim()) {
+    errors.date = REQUIRED_FIELD_MSG + '. Please select a date.';
+  }
+
+  if (new Date(values.date?.trim()) > new Date()) {
+    errors.date = 'Follow up date cannot be set in the future.';
+  }
+
+  if (!values.pain_severity && typeof values.pain_severity !== 'object') {
+    errors.pain_severity = REQUIRED_FIELD_MSG;
+  }
+
+// Does not work, needs more attention
+//     console.log(values)
+//   if (values.attendees?.length === 1) {
+//       console.log(REQUIRED_FIELD_MSG)
+//     errors.attendees = REQUIRED_FIELD_MSG;
+//   }
+
+  if (!values.mesh_awareness && typeof values.mesh_awareness !== 'object') {
+    errors.mesh_awareness = REQUIRED_FIELD_MSG;
+  }
+
+  if (!values.seroma && typeof values.seroma !== 'object') {
+    errors.seroma = REQUIRED_FIELD_MSG;
+  }
+
+  if (!values.infection && typeof values.infection !== 'object') {
+    errors.infection = REQUIRED_FIELD_MSG;
+  }
+
+  if (!values.numbness && typeof values.numbness !== 'object') {
+    errors.numbness = REQUIRED_FIELD_MSG;
+  }
+
+  if (!values.recurrence && typeof values.recurrence !== 'object') {
+    errors.recurrence = REQUIRED_FIELD_MSG;
+  }
+
+  if (!values.further_surgery_need && typeof values.further_surgery_need !== 'object') {
+    errors.further_surgery_need = REQUIRED_FIELD_MSG;
+  }
+
+  return errors;
+};

--- a/src/pages/RegisterEpisode/RegisterEpisode.tsx
+++ b/src/pages/RegisterEpisode/RegisterEpisode.tsx
@@ -22,7 +22,7 @@ import {
 import { useResponsiveLayout } from '../../hooks/useResponsiveSidebar';
 import RegisterEpisodeForm from './components/RegisterEpisodeForm';
 import { RegisterEpisodeFormType } from './types';
-import { formValidation } from './utils';
+import { episodeFormValidation } from './utils';
 
 const RegisterEpisode: React.FC = () => {
   const { isDesktop } = useResponsiveLayout();
@@ -97,7 +97,7 @@ const RegisterEpisode: React.FC = () => {
           mutators={{
             ...arrayMutators,
           }}
-          validate={(values) => formValidation(values, isNewHospital)}
+          validate={(values) => episodeFormValidation(values, isNewHospital)}
           onSubmit={(values) => {
             const newValues = {
               ...values,

--- a/src/pages/RegisterEpisode/RegisterEpisode.tsx
+++ b/src/pages/RegisterEpisode/RegisterEpisode.tsx
@@ -113,7 +113,6 @@ const RegisterEpisode: React.FC = () => {
             form: {
               mutators: { push },
             },
-            valid,
             submitting,
           }) => {
             if (dirty) {
@@ -147,7 +146,7 @@ const RegisterEpisode: React.FC = () => {
                     color={'blue-500'}
                     buttonType="button"
                     onClick={handleSubmit}
-                    disabled={isLoading || !valid || submitting || isSubmitLoading}
+                    disabled={isLoading || submitting || isSubmitLoading}
                     block
                     size="md"
                   >

--- a/src/pages/RegisterEpisode/utils.ts
+++ b/src/pages/RegisterEpisode/utils.ts
@@ -37,6 +37,7 @@ export const formValidation = (values: RegisterEpisodeFormType, isNewHospital: b
     yearOfBirth: '',
     patientHospitalId: '',
     surgeons: '',
+    episodeType: '',
     cepod: '',
     side: '',
     surgeryDate: '',
@@ -59,6 +60,10 @@ export const formValidation = (values: RegisterEpisodeFormType, isNewHospital: b
     errors.patientHospitalId = REQUIRED_FIELD_MSG;
   }
 
+  if (!values.episodeType && typeof values.episodeType !== 'object') {
+    errors.episodeType = REQUIRED_FIELD_MSG
+  }
+
   if (!values.cepod && typeof values.cepod !== 'object') {
     errors.cepod = REQUIRED_FIELD_MSG;
   }
@@ -68,7 +73,7 @@ export const formValidation = (values: RegisterEpisodeFormType, isNewHospital: b
   }
 
   if (!values.surgeryDate?.trim()) {
-    errors.surgeryDate = REQUIRED_FIELD_MSG;
+    errors.surgeryDate = REQUIRED_FIELD_MSG + '. Please select a date.';
   }
 
   if (new Date(values.surgeryDate?.trim()) > new Date()) {

--- a/src/pages/RegisterEpisode/utils.ts
+++ b/src/pages/RegisterEpisode/utils.ts
@@ -29,7 +29,7 @@ export const getSurgeonOptionsSorted = (surgeons: SurgeonsAPI[]): SelectOption[]
   return options;
 };
 
-export const formValidation = (values: RegisterEpisodeFormType, isNewHospital: boolean) => {
+export const episodeFormValidation = (values: RegisterEpisodeFormType, isNewHospital: boolean) => {
   const errors = {} || {
     hospital: '',
     firstName: '',

--- a/src/pages/RegisterPatient/RegisterPatient.tsx
+++ b/src/pages/RegisterPatient/RegisterPatient.tsx
@@ -13,7 +13,7 @@ import { useGetHospitals, useRegisterPatient } from '../../hooks/api/patientHook
 import { useResponsiveLayout } from '../../hooks/useResponsiveSidebar';
 import RegisterPatientForm from './components/RegisterPatientForm';
 import { RegisterPatientFormType } from './types';
-import { formValidation } from './utils';
+import { patientFormValidation } from './utils';
 
 const RegisterPatient: React.FC = () => {
   const { isDesktop } = useResponsiveLayout();
@@ -49,7 +49,7 @@ const RegisterPatient: React.FC = () => {
           </IconWrapper>
           Add new patient
         </PageTitle>
-        <Form onSubmit={handleSubmit} validate={formValidation}>
+        <Form onSubmit={handleSubmit} validate={patientFormValidation}>
           {({ handleSubmit, values, submitting, dirty }) => {
             if (dirty) {
               setIsFormDirty(true);

--- a/src/pages/RegisterPatient/RegisterPatient.tsx
+++ b/src/pages/RegisterPatient/RegisterPatient.tsx
@@ -50,7 +50,7 @@ const RegisterPatient: React.FC = () => {
           Add new patient
         </PageTitle>
         <Form onSubmit={handleSubmit} validate={formValidation}>
-          {({ handleSubmit, values, valid, submitting, dirty }) => {
+          {({ handleSubmit, values, submitting, dirty }) => {
             if (dirty) {
               setIsFormDirty(true);
             }
@@ -70,7 +70,7 @@ const RegisterPatient: React.FC = () => {
                   <Button
                     color={'blue-500'}
                     buttonType="submit"
-                    disabled={isLoading || !valid || submitting}
+                    disabled={isLoading || submitting}
                     block
                     size="md"
                   >

--- a/src/pages/RegisterPatient/components/RegisterPatientForm/RegisterPatientForm.tsx
+++ b/src/pages/RegisterPatient/components/RegisterPatientForm/RegisterPatientForm.tsx
@@ -268,6 +268,24 @@ const RegisterPatientForm: React.FC<Props> = ({ values, hospitals }) => {
               );
             }}
           </Field>
+          <Field name="gender">
+            {(props) => {
+                          const hasError = props.meta.touched && props.meta.invalid && !props.meta.active;
+                          return (
+                            <TextField
+                              id="gender"
+                              label="Gender"
+                              styleType="outlined"
+                              disabled
+                              size="sm"
+                              maxLength={20}
+                              status={hasError ? 'error' : 'hint'}
+                              hintMsg={hasError ? props.meta.error : undefined}
+                              {...props.input}
+                            />
+                          );
+                        }}
+          </Field>
         </FieldsContainer>
       </FormHeadingContainer>
 
@@ -277,13 +295,17 @@ const RegisterPatientForm: React.FC<Props> = ({ values, hospitals }) => {
           <FieldWrapper>
             <Field name="phone1" parse={parseOnlyNumbers}>
               {(props) => {
+                const hasError = props.meta.touched && props.meta.invalid && !props.meta.active;
                 return (
                   <TextField
                     id="phone1"
                     label="Phone #1"
                     styleType="outlined"
+                    required
                     size="sm"
                     maxLength={20}
+                    status={hasError ? 'error' : 'hint'}
+                    hintMsg={hasError ? props.meta.error : undefined}
                     {...props.input}
                   />
                 );

--- a/src/pages/RegisterPatient/utils.ts
+++ b/src/pages/RegisterPatient/utils.ts
@@ -12,7 +12,7 @@ export const getHospitalOptions = (hospitals: HospitalsAPI[]): FilterOption[] =>
   }));
 };
 
-export const formValidation = (values: RegisterPatientFormType) => {
+export const patientFormValidation = (values: RegisterPatientFormType) => {
   const errors = {} || {
     hospital: '',
     firstName: '',

--- a/src/pages/RegisterPatient/utils.ts
+++ b/src/pages/RegisterPatient/utils.ts
@@ -18,7 +18,9 @@ export const formValidation = (values: RegisterPatientFormType) => {
     firstName: '',
     lastName: '',
     yearOfBirth: '',
+    gender: '',
     patientHospitalId: '',
+    phone1: '',
   };
 
   if (!values.hospital && typeof values.hospital !== 'object') {
@@ -37,8 +39,16 @@ export const formValidation = (values: RegisterPatientFormType) => {
     errors.yearOfBirth = REQUIRED_FIELD_MSG;
   }
 
+  if (!values.gender) {
+    errors.gender = REQUIRED_FIELD_MSG + '. Please select the gender above.';
+  }
+
   if (!values.patientHospitalId) {
     errors.patientHospitalId = REQUIRED_FIELD_MSG;
+  }
+
+  if (!values.phone1) {
+    errors.phone1 = REQUIRED_FIELD_MSG;
   }
 
   return errors;


### PR DESCRIPTION
submit buttons are almost always active so when you click on it then forces a validation which shows the error messages on the UI

## Description

The form validation was not working on the UI when creating a patient or registering an episode. This was causing the users a huge confusion on the UI as it could happen that the Submit button was inactive because the form was invalid but the actual error message that explains why the form was invalid was not showing. There were a few different bugs that caused it.

- Like the Patient's gender field cannot be validated nor can show an error message. The workaround was an additional semi hidden field that is tied to the gender radio button but can show the actual error message if the gender is not selected.
- Or the Patient's first phone number was not validated but required which also was confusing as not showing the error message.
- Episode Type was not validated.
These are solved now.

## Screenshot
### Add Patient
#### All Errors
![Screenshot 2025-04-21 at 14 03 00](https://github.com/user-attachments/assets/2e8b49a0-54fc-4c50-8e4c-6de56c9a8420)

#### Gender only Error
![Screenshot 2025-04-21 at 14 04 06](https://github.com/user-attachments/assets/d1bc49ea-1dbe-46d3-85c6-e23e64e12fc6)

### Register Episode
#### All Errors
![Screenshot 2025-04-21 at 14 05 06](https://github.com/user-attachments/assets/5021103b-a042-4067-84ee-0c567ed5ace3)

## Test Plan

We should manually test the
- Patient's registration
   - Submit button should be active at all times from now on
   - Are the existing validations still working: test if fields are missing and try to submit the form then we see the error messages for all missing fields.
   - Is the Gender field showing an error message when it is not selected?
   - Is the first phone number field showing an error message when it is not provided?
- Episode's registration
   - Submit button should be active at all times from now on
   - Episode Type field is validated now: Error message should appear when it is not provided
   - Is the surgery date's error message more helpful when it is missing or not selected?

## Caveats
Input fields are wrapped into the Orfium objects, which limits their usage. This is causing lots of quirky errors and misbehaviours.

### Register Episode
- Surgery Date needs to be clicked and a date selected even if the date is today which is by default selected. Otherwise, the error validation just keeps failing.

### Add Patient
- Gender is only validated when all the other fields are already valid. Therefore, the error is going to show only when all other fields are already valid. Also, the error message cannot be forced on the radio button therefore a new read-only field was introduced to actually make the error message visible.

